### PR TITLE
constructs an absolute path to get_taxon_fun.py based on the location of RFW.py

### DIFF
--- a/RFW.py
+++ b/RFW.py
@@ -193,7 +193,18 @@ if len(mapping_taxa_df)<10:
     sys.exit()
 
 print('Retrieve taxonomy function ...')
-cmdstr='python get_taxon_fun.py '+output_dir+' '+db_place+' '+str(processors)+' '+fun_db_file+' '+anno_type
+
+
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+get_taxon_fun_path = os.path.join(script_dir, 'get_taxon_fun.py')
+
+if not os.path.exists(get_taxon_fun_path):
+    raise FileNotFoundError(f'Cannot find get_taxon_fun.py at {get_taxon_fun_path}')
+
+cmdstr = f'python "{get_taxon_fun_path}" "{output_dir}" "{db_place}" "{processors}" "{fun_db_file}" "{anno_type}"'
+
+
 #print(cmdstr)
 os.system(cmdstr)
 print('Calculate function abundance...')

--- a/RFW.py
+++ b/RFW.py
@@ -257,7 +257,16 @@ else:
 
 print('Calculate taxon contribution to functions...')
 
-cmdstr='python get_fun_contri.py '+output_dir + '/taxon_fun/'+anno_type+'fun_taxon.csv'+' '+output_dir+' '+output_dir + '/rel_abu.csv'+' '+str(processors)
+get_fun_contri_path = os.path.join(script_dir, 'get_fun_contri.py')
+
+if not os.path.exists(get_fun_contri_path):
+    raise FileNotFoundError(f'Cannot find get_fun_contri.py at {get_fun_contri_path}')
+
+fun_taxon_csv = os.path.join(output_dir, 'taxon_fun', f'{anno_type}fun_taxon.csv')
+rel_abu_csv = os.path.join(output_dir, 'rel_abu.csv')
+
+cmdstr = f'python "{get_fun_contri_path}" "{fun_taxon_csv}" "{output_dir}" "{rel_abu_csv}" "{processors}"'
+
 #print(cmdstr)
 os.system(cmdstr)
 


### PR DESCRIPTION
Fixes this error when not running from within RFW folder.

```
Map taxonomy ...
Retrieve taxonomy function ...
python: can't open file '/home/harry/.local/lib/RFW/get_taxon_fun.py': [Errno 2] No such file or directory
Calculate function abundance...
Traceback (most recent call last):
  File "/home/harry/.local/lib/RFW/RFW.py", line 208, in <module>
    fun_taxon=pd.concat(fun_taxon)
  File "/home/harry/.local/lib/python3.10/site-packages/pandas/core/reshape/concat.py", line 372, in concat
    op = _Concatenator(
  File "/home/harry/.local/lib/python3.10/site-packages/pandas/core/reshape/concat.py", line 429, in __init__
    raise ValueError("No objects to concatenate")
ValueError: No objects to concatenate
```